### PR TITLE
Fix issue #6 and issue #5.

### DIFF
--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Linq.Expressions;
-using System.Reflection;
 using SpiceSharp;
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
-using SpiceSharpBehavioral.Parsers;
 
 namespace Benchmark
 {
@@ -15,13 +12,14 @@ namespace Benchmark
             var ckt = new Circuit(
                 new VoltageSource("V1", "in", "0", 1),
                 new Resistor("R1", "in", "0", 1),
-                new BehavioralVoltageSource("E1", "out", "0", "I(V1)*10"));
+                new BehavioralVoltageSource("E1", "out", "0", "Pow(V(in),3)"));
 
-            var op = new OP("op");
+            var op = new DC("dc", "V1", -1, 1, 0.1);
             var export = new RealCurrentExport(op, "V1");
             op.ExportSimulationData += (sender, e) =>
             {
-                Console.WriteLine(export.Value);
+                Console.Write(export.Value);
+                Console.Write(" -> ");
                 Console.WriteLine(e.GetVoltage("out"));
             };
             op.Run(ckt);

--- a/SpiceSharpBehavioral/Parsers/Derivatives/Derivatives.cs
+++ b/SpiceSharpBehavioral/Parsers/Derivatives/Derivatives.cs
@@ -12,6 +12,19 @@ namespace SpiceSharpBehavioral.Parsers
         private T[] _derivatives;
 
         /// <summary>
+        /// Gets or sets the fudge factor for numerical edge-cases.
+        /// </summary>
+        /// <remarks>
+        /// One should not be able to divide by 0, or raise 0 to a negative power. However, the simulator
+        /// may not know this, so we introduce a fudge factor to remove this.
+        /// If the exact solution is expected, use 0 as the fudge factor.
+        /// </remarks>
+        /// <value>
+        /// The fudge factor.
+        /// </value>
+        public static double FudgeFactor { get; set; } = 1e-30;
+
+        /// <summary>
         /// Gets the number of derivatives.
         /// </summary>
         /// <value>

--- a/SpiceSharpBehavioral/Parsers/Operators/TernaryOperator.cs
+++ b/SpiceSharpBehavioral/Parsers/Operators/TernaryOperator.cs
@@ -20,7 +20,7 @@ namespace SpiceSharpBehavioral.Parsers.Operators
         /// Initializes a new instance of the <see cref="TernaryOperator"/> class.
         /// </summary>
         public TernaryOperator()
-            : base(OperatorType.OpenTernary, (int) OperatorPrecedence.Unary, false)
+            : base(OperatorType.OpenTernary, (int) OperatorPrecedence.Conditional, false)
         {
             Closed = false;
         }

--- a/SpiceSharpBehavioral/SpiceSharpBehavioral.csproj
+++ b/SpiceSharpBehavioral/SpiceSharpBehavioral.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45;netcoreapp2.0</TargetFrameworks>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Authors>Sven Boulanger</Authors>
 	  <Title>Spice#.Behavioral</Title>
     <Description>Spice#.Behavioral is a library that allows using behavioral components in the circuit simulator Spice#.</Description>
@@ -11,12 +11,12 @@
     <RepositoryUrl>https://github.com/SpiceSharp/SpiceSharpBehavioral</RepositoryUrl>
     <PackageTags>circuit electronics netlist parser spice simulator simulation ode solver design behavioral modeling</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/SpiceSharp/SpiceSharp/master/api/images/logo_full.svg?sanitize=true</PackageIconUrl>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
     <PackageReleaseNotes>Refer to the GitHub release for release notes.</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company />
     <NeutralLanguage>en</NeutralLanguage>
-    <FileVersion>1.1.0.0</FileVersion>
+    <FileVersion>1.1.1.0</FileVersion>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/SpiceSharpBehavioralTests/Components/Framework.cs
+++ b/SpiceSharpBehavioralTests/Components/Framework.cs
@@ -3,10 +3,7 @@ using SpiceSharp;
 using SpiceSharp.Simulations;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SpiceSharpBehavioralTests.Components
 {

--- a/SpiceSharpBehavioralTests/Parsers/ExpressionTreeDerivativeParserTests.cs
+++ b/SpiceSharpBehavioralTests/Parsers/ExpressionTreeDerivativeParserTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using NUnit.Framework;
@@ -79,7 +78,7 @@ namespace SpiceSharpBehavioralTests.Parsers
                 x[i] = -2.0;
             while (true)
             {
-                
+                Derivatives<Expression>.FudgeFactor = 0.0;
                 for (var i = 0; i < reference.Length; i++)
                 {
                     var expected = reference[i](x);
@@ -152,6 +151,14 @@ namespace SpiceSharpBehavioralTests.Parsers
             Check(2 * (2 + 3) * 4, parser.Parse("2 * ((2 + 3)) * 4"));
         }
 
+        [Test]
+        public void When_Conditional_Expect_Reference()
+        {
+            var parser = new ExpressionTreeDerivativeParser();
+            Check(1, parser.Parse("1 >= 0 ? 1 : 2"));
+            Check(2, parser.Parse("1 >= 3 ? 1 : 2"));
+        }
+
         private ExpressionTreeDerivativeParser Parser
         {
             get
@@ -167,12 +174,12 @@ namespace SpiceSharpBehavioralTests.Parsers
         {
             var parser = Parser;
             Check(new Func<double[], double>[] { x => 6 * x[0], x => 6 }, parser, "6*a");
-            Check(new Func<double[], double>[] { x => x[0] * x[0], x => 2 * x[0] }, parser, "a^2");
+            Check(new Func<double[], double>[] { x => x[0] * Math.Abs(x[0]), x => 2 * Math.Abs(x[0]) }, parser, "a^2");
             Check(new Func<double[], double>[] { x => x[0] * (x[0] - 3), x => 2 * x[0] - 3 }, parser, "a * (a - 3)");
             Check(new Func<double[], double>[] { x => 1 / Math.Pow(x[0], 3), x => -3 * Math.Pow(x[0], 2) / Math.Pow(x[0], 6) }, parser, "1 / a^3");
             Check(new Func<double[], double>[] { x => 2 * x[0] + 3 * x[1], x => 2, x => 3 }, parser, "2 * a + 3 * b");
             Check(new Func<double[], double>[] { x => x[0] * x[1], x => x[1], x => x[0] }, parser, "a * b");
-            Check(new Func<double[], double>[] { x => Math.Pow(x[0], x[1]), x => x[1] * Math.Pow(x[0], x[1] - 1), x => Math.Log(x[0]) * Math.Pow(x[0], x[1]) }, parser, "a^b");
+            Check(new Func<double[], double>[] { x => x[0] < 0 ? -Math.Pow(-x[0], x[1]) : Math.Pow(x[0], x[1]), x => x[1] * Math.Pow(Math.Abs(x[0]), x[1] - 1), x => Math.Log(Math.Abs(x[0])) * Math.Pow(Math.Abs(x[0]), x[1]) }, parser, "a^b");
         }
 
         [Test]
@@ -267,15 +274,13 @@ namespace SpiceSharpBehavioralTests.Parsers
             var parser = Parser;
             Check(x => Math.Min(x, 1), parser, "Min(x, 1)");
             Check(new Func<double[], double>[] {
-                x => Math.Min((x[0] + 0.5) * (x[0] + 0.5), Math.Min(x[0] * x[0], (x[0] - 0.5) * (x[0] - 0.5))),
+                x => Math.Min(x[0] < 0 ? -x[0] * x[0] : x[0] * x[0], x[0]),
                 x =>
                 {
-                    if (x[0] < -0.25)
-                        return 2 * (x[0] + 0.5);
-                    if (x[0] < 0.25)
-                        return 2 * x[0];
-                    return 2 * (x[0] - 0.5);
-                }}, parser, "Min((a+0.5)^2, a^2, (a-0.5)^2)");
+                    if (x[0] < -1 || (x[0] > 0 && x[0] < 1))
+                        return Math.Abs(x[0]) * 2;
+                    return 1.0;
+                }}, parser, "Min(a^2, a)");
         }
 
         [Test]
@@ -284,15 +289,13 @@ namespace SpiceSharpBehavioralTests.Parsers
             var parser = Parser;
             Check(x => Math.Max(x, 1), parser, "Max(x, 1)");
             Check(new Func<double[], double>[] {
-                x => Math.Max(-(x[0] + 0.5) * (x[0] + 0.5), Math.Max(-x[0] * x[0], -(x[0] - 0.5) * (x[0] - 0.5))),
+                x => Math.Max(x[0] < 0 ? -x[0] * x[0] : x[0] * x[0], x[0]),
                 x =>
                 {
-                    if (x[0] < -0.25)
-                        return -2 * (x[0] + 0.5);
-                    if (x[0] < 0.25)
-                        return -2 * x[0];
-                    return -2 * (x[0] - 0.5);
-                }}, parser, "Max(-(a+0.5)^2, -a^2, -(a-0.5)^2)");
+                    if (x[0] > 1 || (x[0] < 0 && x[0] > -1))
+                        return Math.Abs(x[0]) * 2;
+                    return 1.0;
+                }}, parser, "Max(a^2, a)");
         }
     }
 }

--- a/SpiceSharpBehavioralTests/Parsers/ExpressionTreeParserTests.cs
+++ b/SpiceSharpBehavioralTests/Parsers/ExpressionTreeParserTests.cs
@@ -63,6 +63,14 @@ namespace SpiceSharpBehavioralTests.Parsers
             Check(2 * (2 + 3) * 4, parser.Parse("2 * ((2 + 3)) * 4"));
         }
 
+        [Test]
+        public void When_Conditional_Expect_Reference()
+        {
+            var parser = new ExpressionTreeParser();
+            Check(1, parser.Parse("1 >= 0 ? 1 : 2"));
+            Check(2, parser.Parse("1 >= 3 ? 1 : 2"));
+        }
+
         private ExpressionTreeParser Parser
         {
             get

--- a/SpiceSharpBehavioralTests/Parsers/SimpleParserTests.cs
+++ b/SpiceSharpBehavioralTests/Parsers/SimpleParserTests.cs
@@ -60,6 +60,14 @@ namespace SpiceSharpBehavioralTests.Parsers
             Check(2 * (2 + 3) * 4, parser.Parse("2 * ((2 + 3)) * 4"));
         }
 
+        [Test]
+        public void When_Conditional_Expect_Reference()
+        {
+            var parser = new SimpleParser();
+            Check(1, parser.Parse("1 >= 0 ? 1 : 2"));
+            Check(2, parser.Parse("1 >= 3 ? 1 : 2"));
+        }
+
         private SimpleParser Parser
         {
             get

--- a/SpiceSharpBehavioralTests/Properties/AssemblyInfo.cs
+++ b/SpiceSharpBehavioralTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("SpiceSharpBehavioralTests")]


### PR DESCRIPTION
Pow() was made antisymmetrical like other Spice simulators, and a fudge factor can now avoid numerical edge cases. Ternary operator was also fixed.