### PR TITLE
When an expression is long, there is a System.NotSupportedException

### DIFF
--- a/SpiceSharpBehavioral/Builders/Functions/RealILState.cs
+++ b/SpiceSharpBehavioral/Builders/Functions/RealILState.cs
@@ -70,25 +70,25 @@ namespace SpiceSharpBehavioral.Builders.Functions
                         case NodeTypes.GreaterThan:
                             Push(bn.Left);
                             Push(bn.Right);
-                            PushCheck(OpCodes.Bgt_S, 1.0, 0.0);
+                            PushCheck(OpCodes.Bgt, 1.0, 0.0);
                             return;
 
                         case NodeTypes.LessThan:
                             Push(bn.Left);
                             Push(bn.Right);
-                            PushCheck(OpCodes.Blt_S, 1.0, 0.0);
+                            PushCheck(OpCodes.Blt, 1.0, 0.0);
                             return;
 
                         case NodeTypes.GreaterThanOrEqual:
                             Push(bn.Left);
                             Push(bn.Right);
-                            PushCheck(OpCodes.Bge_S, 1.0, 0.0);
+                            PushCheck(OpCodes.Bge, 1.0, 0.0);
                             return;
 
                         case NodeTypes.LessThanOrEqual:
                             Push(bn.Left);
                             Push(bn.Right);
-                            PushCheck(OpCodes.Ble_S, 1.0, 0.0);
+                            PushCheck(OpCodes.Ble, 1.0, 0.0);
                             return;
 
                         case NodeTypes.Equals:
@@ -97,7 +97,7 @@ namespace SpiceSharpBehavioral.Builders.Functions
                             Push(Builder.RelativeTolerance);
                             Push(Builder.AbsoluteTolerance);
                             Generator.Emit(OpCodes.Call, _equals);
-                            PushCheck(OpCodes.Brtrue_S, 1.0, 0.0);
+                            PushCheck(OpCodes.Brtrue, 1.0, 0.0);
                             return;
 
                         case NodeTypes.NotEquals:
@@ -106,7 +106,7 @@ namespace SpiceSharpBehavioral.Builders.Functions
                             Push(Builder.RelativeTolerance);
                             Push(Builder.AbsoluteTolerance);
                             Generator.Emit(OpCodes.Call, _equals);
-                            PushCheck(OpCodes.Brfalse_S, 1.0, 0.0);
+                            PushCheck(OpCodes.Brfalse, 1.0, 0.0);
                             return;
 
                         case NodeTypes.And:
@@ -114,11 +114,11 @@ namespace SpiceSharpBehavioral.Builders.Functions
                             lblEnd = Generator.DefineLabel();
 
                             Push(bn.Left); Push(0.5);
-                            Generator.Emit(OpCodes.Ble_S, lblBypass);
+                            Generator.Emit(OpCodes.Ble, lblBypass);
                             Push(bn.Right); Push(0.5);
-                            Generator.Emit(OpCodes.Ble_S, lblBypass);
+                            Generator.Emit(OpCodes.Ble, lblBypass);
                             Generator.Emit(OpCodes.Ldc_R8, 1.0);
-                            Generator.Emit(OpCodes.Br_S, lblEnd);
+                            Generator.Emit(OpCodes.Br, lblEnd);
                             Generator.MarkLabel(lblBypass);
                             Generator.Emit(OpCodes.Ldc_R8, 0.0);
                             Generator.MarkLabel(lblEnd);
@@ -129,11 +129,11 @@ namespace SpiceSharpBehavioral.Builders.Functions
                             lblEnd = Generator.DefineLabel();
 
                             Push(bn.Left); Push(0.5);
-                            Generator.Emit(OpCodes.Bgt_S, lblBypass);
+                            Generator.Emit(OpCodes.Bgt, lblBypass);
                             Push(bn.Right); Push(0.5);
-                            Generator.Emit(OpCodes.Bgt_S, lblBypass);
+                            Generator.Emit(OpCodes.Bgt, lblBypass);
                             Generator.Emit(OpCodes.Ldc_R8, 0.0);
-                            Generator.Emit(OpCodes.Br_S, lblEnd);
+                            Generator.Emit(OpCodes.Br, lblEnd);
                             Generator.MarkLabel(lblBypass);
                             Generator.Emit(OpCodes.Ldc_R8, 1.0);
                             Generator.MarkLabel(lblEnd);
@@ -166,7 +166,7 @@ namespace SpiceSharpBehavioral.Builders.Functions
                         case NodeTypes.Minus: Generator.Emit(OpCodes.Neg); return;
                         case NodeTypes.Not:
                             Push(0.5);
-                            PushCheck(OpCodes.Ble_S, 1.0, 0.0);
+                            PushCheck(OpCodes.Ble, 1.0, 0.0);
                             return;
                     }
                     break;
@@ -191,9 +191,9 @@ namespace SpiceSharpBehavioral.Builders.Functions
                     lblBypass = Generator.DefineLabel();
                     lblEnd = Generator.DefineLabel();
                     Push(tn.Condition); Push(0.5);
-                    Generator.Emit(OpCodes.Ble_S, lblBypass);
+                    Generator.Emit(OpCodes.Ble, lblBypass);
                     Push(tn.IfTrue);
-                    Generator.Emit(OpCodes.Br_S, lblEnd);
+                    Generator.Emit(OpCodes.Br, lblEnd);
                     Generator.MarkLabel(lblBypass);
                     Push(tn.IfFalse);
                     Generator.MarkLabel(lblEnd);

--- a/SpiceSharpBehavioralTest/Components/BehavioralResistorTests.cs
+++ b/SpiceSharpBehavioralTest/Components/BehavioralResistorTests.cs
@@ -9,6 +9,23 @@ namespace SpiceSharpBehavioralTest.Components
     public class BehavioralResistorTests
     {
         [Test]
+        public void When_ComplexResitor_Expect_Reference()
+        {
+            var ckt = new Circuit(
+                new VoltageSource("V1", "2", "0", 0.5),
+                new VoltageSource("V2", "1", "0", 10),
+                new BehavioralResistor("RSwitch", "1", "0", "v(2, 0) >= 1 ? 10 : (v(2, 0) <= 0 ? 1000000 : (exp(8.05904782547916 + 3 * -11.5129254649702 * (v(2, 0)-0.5)/(2*1) - 2 * -11.5129254649702 * pow(v(2, 0)-0.5, 3)/(pow(1,3)))))"));
+            var op = new OP("Voltage switch simulation");
+            var refExport = new RealCurrentExport(op, "V2");
+            op.ExportSimulationData += (sender, args) =>
+            {
+                Assert.AreEqual(-0.00316228, refExport.Value, 1e-8);
+            };
+
+            op.Run(ckt);
+        }
+
+        [Test]
         public void When_SimpleResistor_Expect_Reference()
         {
             var ckt = new Circuit(


### PR DESCRIPTION
Unhandled exception. System.NotSupportedException: Illegal one-byte branch at position: xxx. Requested branch was: yyy.
   at System.Reflection.Emit.ILGenerator.BakeByteArray()
